### PR TITLE
Lambda node 18 to 22

### DIFF
--- a/infrastructure/src/constructs/lambda-construct.ts
+++ b/infrastructure/src/constructs/lambda-construct.ts
@@ -79,7 +79,7 @@ function. This function to process and transform raw events before they get writ
       ),
       memorySize: 128,
       timeout: cdk.Duration.seconds(60),
-      runtime: lambda.Runtime.NODEJS_18_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       environment: {
         AUTHORIZATIONS_TABLE: props.authorizationsTable.tableName,
         APPLICATION_AUTHORIZATIONS_INDEX: "ApplicationAuthorizations",

--- a/infrastructure/src/constructs/lambda-construct.ts
+++ b/infrastructure/src/constructs/lambda-construct.ts
@@ -61,7 +61,7 @@ function. This function to process and transform raw events before they get writ
         ),
         memorySize: 256,
         timeout: cdk.Duration.minutes(5),
-        runtime: lambda.Runtime.NODEJS_18_X,
+        runtime: lambda.Runtime.NODEJS_22_X,
         environment: {
           APPLICATIONS_TABLE: props.applicationsTable.tableName,
           CACHE_TIMEOUT_SECONDS: "60",

--- a/infrastructure/src/constructs/lambda-construct.ts
+++ b/infrastructure/src/constructs/lambda-construct.ts
@@ -103,7 +103,7 @@ This function provides the application admin microservice. */
 
         memorySize: 128,
         timeout: cdk.Duration.seconds(60),
-        runtime: lambda.Runtime.NODEJS_18_X,
+        runtime: lambda.Runtime.NODEJS_22_X,
         environment: {
           AUTHORIZATIONS_TABLE: props.authorizationsTable.tableName,
           APPLICATION_AUTHORIZATIONS_INDEX: "ApplicationAuthorizations",

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "deploy.bootstrap": "cd infrastructure && npm install && npm run bootstrap",
     "deploy": "cd infrastructure && npm run cdk deploy -- -c stack_name=\"${STACK_NAME:-}\" --all --require-approval never",
     "destroy": "cd infrastructure && npm run cdk destroy -- -c stack_name=\"${STACK_NAME:-}\" --all"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.2"
   }
 }


### PR DESCRIPTION
*Description of changes:*

Upgraded lambda functions from node 18 (EOL) to node 22.

Added esbuild as a development dependency in the root package.json to speed up build times.

Quote from the [CDK documentation](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs-readme.html#local-bundling)
> For macOS the recommended approach is to install esbuild as Docker volume performance is really poor.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
