### PR TITLE
Use firehose name for DeliveryStreamName

### DIFF
--- a/infrastructure/terraform/src/constructs/api-construct/main.tf
+++ b/infrastructure/terraform/src/constructs/api-construct/main.tf
@@ -80,7 +80,7 @@ locals {
       DIRECT_BATCH = {
           value = <<EOT
 {
-                            "DeliveryStreamName": "${var.game_events_firehose_arn}",
+                            "DeliveryStreamName": "${var.game_events_firehose_name}",
                             "Records": [
                                 #set($i = 0)
                                 #foreach($event in $input.path('$.events'))

--- a/infrastructure/terraform/src/constructs/api-construct/variables.tf
+++ b/infrastructure/terraform/src/constructs/api-construct/variables.tf
@@ -23,6 +23,11 @@ variable "game_events_firehose_arn" {
   description = "ARN of the Firehose stream for game events"
 }
 
+variable "game_events_firehose_name" {
+  type = string
+  description = "Name of the Firehose stream for game events"
+}
+
 variable "ingest_mode" {
   type = string
   description = "Streaming mode of the ingest"

--- a/infrastructure/terraform/src/main.tf
+++ b/infrastructure/terraform/src/main.tf
@@ -616,6 +616,7 @@ module "games_api_construct" {
   game_events_stream_arn = local.config.INGEST_MODE == "KINESIS_DATA_STREAMS" ? aws_kinesis_stream.game_events_stream[0].arn : ""
   game_events_stream_name = local.config.INGEST_MODE == "KINESIS_DATA_STREAMS" ? aws_kinesis_stream.game_events_stream[0].name : ""
   game_events_firehose_arn = local.config.INGEST_MODE == "DIRECT_BATCH" ? module.streaming_ingestion_construct[0].game_events_firehose_arn : ""
+  game_events_firehose_name = local.config.INGEST_MODE == "DIRECT_BATCH" ? module.streaming_ingestion_construct[0].game_events_firehose_name : ""
   application_admin_service_function_arn = module.lambda_construct.application_admin_service_function_arn
   stack_name = local.config.WORKLOAD_NAME
   api_stage_name = local.config.API_STAGE_NAME


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Using the ARN makes the PutRecordBatch API calls not match the IAM policy.

Otherwise creating events will result in an error like this

```
{
    "__type": "AccessDeniedException",
    "Message": "User: arn:aws:sts::209350187543:assumed-role/game-analytics-pipeline-ApiGatewayRole/BackplaneAssumeRoleSession is not authorized to perform: firehose:PutRecordBatch on resource: arn:aws:firehose:eu-north-1:209350187543:deliverystream/arn:aws:firehose:eu-north-1:209350187543:deliverystream/game-analytics-pipeline-game-events-firehose-fhvibkk8 because no identity-based policy allows the firehose:PutRecordBatch action"
}
```

Note that the ARN contains the account and region again instead of just the name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
