### PR TITLE
Update Athena sample queries for new event_timestamp schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ cdk.out
 .history/
 *.vsix
 
+# Kiro
+.kiro/
+
 # Terraform
 .terraform
 .terraform.lock.hcl

--- a/infrastructure/aws-cdk/src/constructs/samples/athena-construct.ts
+++ b/infrastructure/aws-cdk/src/constructs/samples/athena-construct.ts
@@ -48,7 +48,7 @@ export class AthenaQueryConstruct extends Construct {
         name: "LatestEventsQuery",
         description: "Get latest events by event_timestamp",
         workgroup: workgroupName,
-        query: `SELECT *, from_unixtime(event_timestamp, 'America/New_York') as event_timestamp_america_new_york
+        query: `SELECT *, event_timestamp AT TIME ZONE 'America/New_York' as event_timestamp_america_new_york
                 FROM "${databaseName}"."${tableName}"
                 ORDER BY event_timestamp_america_new_york DESC
                 LIMIT 10;`,
@@ -68,11 +68,11 @@ export class AthenaQueryConstruct extends Construct {
         description: "Total events over last month",
         workgroup: workgroupName,
         query: `WITH detail AS
-                (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, * 
+                (SELECT date_trunc('month', event_timestamp) as event_month, * 
                 FROM "${databaseName}"."${tableName}") 
-                SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT event_id) as event_count 
+                SELECT event_month as month, application_id, count(DISTINCT event_id) as event_count 
                 FROM detail 
-                GROUP BY date_trunc('month', event_month), application_id`,
+                GROUP BY event_month, application_id`,
       },
       {
         database: databaseName,
@@ -80,12 +80,12 @@ export class AthenaQueryConstruct extends Construct {
         description: "Total IAP Transactions over the last month",
         workgroup: workgroupName,
         query: `WITH detail AS 
-                (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day),'%Y-%m-%d'))) as event_month,* 
+                (SELECT date_trunc('month', event_timestamp) as event_month, * 
                 FROM "${databaseName}"."${tableName}") 
-                SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
+                SELECT event_month as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
                 FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
                 AND event_type = 'iap_transaction'
-                GROUP BY date_trunc('month', event_month), application_id`,
+                GROUP BY event_month, application_id`,
       },
       {
         database: databaseName,
@@ -93,14 +93,14 @@ export class AthenaQueryConstruct extends Construct {
         description: "New Users over the last month",
         workgroup: workgroupName,
         query: `WITH detail AS (
-                SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, *
+                SELECT date_trunc('month', event_timestamp) as event_month, *
                 FROM "${databaseName}"."${tableName}")
                 SELECT
-                date_trunc('month', event_month) as month,
+                event_month as month,
                 count(*) as new_accounts
                 FROM detail
                 WHERE event_type = 'user_registration'
-                GROUP BY date_trunc('month', event_month);`,
+                GROUP BY event_month;`,
       },
       {
         database: databaseName,
@@ -167,10 +167,10 @@ export class AthenaQueryConstruct extends Construct {
         workgroup: workgroupName,
         query: `SELECT
                 avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
-                date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d')) as event_date
+                date(event_timestamp) as event_date
                 FROM "${databaseName}"."${tableName}"
                 WHERE json_extract_scalar(event_data, '$.user_rating') is not null
-                GROUP BY date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'));`,
+                GROUP BY date(event_timestamp);`,
       },
       {
         database: databaseName,
@@ -187,12 +187,12 @@ export class AthenaQueryConstruct extends Construct {
         name: "CTASCreateIcebergTables",
         description: "Create table as (CTAS) from existing tables to iceberg",
         workgroup: workgroupName,
-        query: `CREATE TABLE "${tableName}"."raw_events_iceberg"
+        query: `CREATE TABLE "${databaseName}"."raw_events_iceberg"
                 WITH (table_type = 'ICEBERG',
                     format = 'PARQUET', 
                     location = 's3://your_bucket/', 
                     is_external = false,
-                    partitioning = ARRAY['application_id', 'year', 'month', 'day'],
+                    partitioning = ARRAY['application_id', 'month(event_timestamp)'],
                     vacuum_min_snapshots_to_keep = 10,
                     vacuum_max_snapshot_age_seconds = 604800
                 ) 

--- a/infrastructure/aws-cdk/src/constructs/samples/athena-construct.ts
+++ b/infrastructure/aws-cdk/src/constructs/samples/athena-construct.ts
@@ -30,12 +30,17 @@ export interface AthenaQueryConstructProps extends cdk.StackProps {
 
 const defaultProps: Partial<AthenaQueryConstructProps> = {};
 
-interface AthenaNamedQuery {
-  database: string;
+/**
+ * Query string for a named query. Use a plain string for schema-agnostic
+ * queries, or an object with per-schema variants when the query depends on
+ * whether the raw_events_table uses the Iceberg or Hive schema.
+ */
+type QueryString = string | { iceberg: string; hive: string };
+
+interface QueryDefinition {
   name: string;
   description: string;
-  workgroup: string;
-  query: string;
+  query: QueryString;
 }
 
 /**
@@ -45,359 +50,210 @@ interface AthenaNamedQuery {
  */
 export class AthenaQueryConstruct extends Construct {
 
-  /**
-   * Queries against the Iceberg-backed raw_events_table, where event_timestamp
-   * is a native timestamp column (no year/month/day partition columns).
-   */
-  private buildIcebergQueries(
-    databaseName: string,
-    tableName: string,
-    workgroupName: string
-  ): AthenaNamedQuery[] {
-    return [
-      {
-        database: databaseName,
-        name: "LatestEventsQuery",
-        description: "Get latest events by event_timestamp",
-        workgroup: workgroupName,
-        query: `SELECT *, event_timestamp AT TIME ZONE 'America/New_York' as event_timestamp_america_new_york
-                FROM "${databaseName}"."${tableName}"
-                ORDER BY event_timestamp_america_new_york DESC
-                LIMIT 10;`,
-      },
-      {
-        database: databaseName,
-        name: "TotalEventsQuery",
-        description: "Total events",
-        workgroup: workgroupName,
-        query: `SELECT application_id, count(DISTINCT event_id) as event_count 
-                FROM "${databaseName}"."${tableName}"
-                GROUP BY application_id`,
-      },
-      {
-        database: databaseName,
-        name: "TotalEventsMonthQuery",
-        description: "Total events over last month",
-        workgroup: workgroupName,
-        query: `WITH detail AS
-                (SELECT date_trunc('month', event_timestamp) as event_month, * 
-                FROM "${databaseName}"."${tableName}") 
-                SELECT event_month as month, application_id, count(DISTINCT event_id) as event_count 
-                FROM detail 
-                GROUP BY event_month, application_id`,
-      },
-      {
-        database: databaseName,
-        name: "TotalIapTransactionsLastMonth",
-        description: "Total IAP Transactions over the last month",
-        workgroup: workgroupName,
-        query: `WITH detail AS 
-                (SELECT date_trunc('month', event_timestamp) as event_month, * 
-                FROM "${databaseName}"."${tableName}") 
-                SELECT event_month as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
-                FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
-                AND event_type = 'iap_transaction'
-                GROUP BY event_month, application_id`,
-      },
-      {
-        database: databaseName,
-        name: "NewUsersLastMonth",
-        description: "New Users over the last month",
-        workgroup: workgroupName,
-        query: `WITH detail AS (
-                SELECT date_trunc('month', event_timestamp) as event_month, *
-                FROM "${databaseName}"."${tableName}")
-                SELECT
-                event_month as month,
-                count(*) as new_accounts
-                FROM detail
-                WHERE event_type = 'user_registration'
-                GROUP BY event_month;`,
-      },
-      {
-        database: databaseName,
-        name: "TotalPlaysByLevel",
-        description: "Total number of times each level has been played",
-        workgroup: workgroupName,
-        query: `SELECT
-                json_extract_scalar(event_data, '$.level_id') as level,
-                count(json_extract_scalar(event_data, '$.level_id')) as number_of_plays
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type = 'level_started'
-                GROUP BY json_extract_scalar(event_data, '$.level_id')
-                ORDER by json_extract_scalar(event_data, '$.level_id');`,
-      },
-      {
-        database: databaseName,
-        name: "TotalFailuresByLevel",
-        description: "Total number of failures on each level",
-        workgroup: workgroupName,
-        query: `SELECT
-                json_extract_scalar(event_data, '$.level_id') as level,
-                count(json_extract_scalar(event_data, '$.level_id')) as number_of_failures
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type='level_failed'
-                GROUP BY json_extract_scalar(event_data, '$.level_id')
-                ORDER by json_extract_scalar(event_data, '$.level_id');`,
-      },
-      {
-        database: databaseName,
-        name: "TotalCompletionsByLevel",
-        description: "Total number of completions on each level",
-        workgroup: workgroupName,
-        query: `SELECT
-                json_extract_scalar(event_data, '$.level_id') as level,
-                count(json_extract_scalar(event_data, '$.level_id')) as number_of_completions
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type='level_completed'
-                GROUP BY json_extract_scalar(event_data, '$.level_id')
-                ORDER by json_extract_scalar(event_data, '$.level_id');`,
-      },
-      {
-        database: databaseName,
-        name: "LevelCompletionRate",
-        description: "Rate of completion for each level",
-        workgroup: workgroupName,
-        query: `with t1 as
-                (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type='level_started' GROUP BY json_extract_scalar(event_data, '$.level_id') 
-                ),
-                t2 as
-                (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type='level_completed'GROUP BY json_extract_scalar(event_data, '$.level_id') 
-                )
-                select t2.level, (cast(t2.level_count AS DOUBLE) / (cast(t2.level_count AS DOUBLE) + cast(t1.level_count AS DOUBLE))) * 100 as level_completion_rate from 
-                t1 JOIN t2 ON t1.level = t2.level
-                ORDER by level;`,
-      },
-      {
-        database: databaseName,
-        name: "AverageUserSentimentPerDay",
-        description: "User sentiment score by day",
-        workgroup: workgroupName,
-        query: `SELECT
-                avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
-                date(event_timestamp) as event_date
-                FROM "${databaseName}"."${tableName}"
-                WHERE json_extract_scalar(event_data, '$.user_rating') is not null
-                GROUP BY date(event_timestamp);`,
-      },
-      {
-        database: databaseName,
-        name: "UserReportedReasonsCount",
-        description: "Reasons users are being reported, grouped by reason code",
-        workgroup: workgroupName,
-        query: `SELECT count(json_extract_scalar(event_data, '$.report_reason')) as count_of_reports, json_extract_scalar(event_data, '$.report_reason') as report_reason
-                FROM "${databaseName}"."${tableName}"
-                GROUP BY json_extract_scalar(event_data, '$.report_reason')
-                ORDER BY json_extract_scalar(event_data, '$.report_reason') DESC;`,
-      },
-      {
-        database: databaseName,
-        name: "CTASCreateIcebergTables",
-        description: "Create table as (CTAS) from existing tables to iceberg",
-        workgroup: workgroupName,
-        query: `CREATE TABLE "${databaseName}"."raw_events_iceberg"
-                WITH (table_type = 'ICEBERG',
-                    format = 'PARQUET', 
-                    location = 's3://your_bucket/', 
-                    is_external = false,
-                    partitioning = ARRAY['application_id', 'month(event_timestamp)'],
-                    vacuum_min_snapshots_to_keep = 10,
-                    vacuum_max_snapshot_age_seconds = 604800
-                ) 
-                AS SELECT * FROM "${databaseName}"."${tableName}";`,
-      },
-    ];
-  }
-
-  /**
-   * Queries against Hive-partitioned raw_events_table, where
-   * year/month/day are partition columns and event_timestamp is a Unix epoch.
-   */
-  private buildHiveQueries(
-    databaseName: string,
-    tableName: string,
-    workgroupName: string
-  ): AthenaNamedQuery[] {
-    return [
-      {
-        database: databaseName,
-        name: "LatestEventsQuery",
-        description: "Get latest events by event_timestamp",
-        workgroup: workgroupName,
-        query: `SELECT *, from_unixtime(event_timestamp, 'America/New_York') as event_timestamp_america_new_york
-                FROM "${databaseName}"."${tableName}"
-                ORDER BY event_timestamp_america_new_york DESC
-                LIMIT 10;`,
-      },
-      {
-        database: databaseName,
-        name: "TotalEventsQuery",
-        description: "Total events",
-        workgroup: workgroupName,
-        query: `SELECT application_id, count(DISTINCT event_id) as event_count 
-                FROM "${databaseName}"."${tableName}"
-                GROUP BY application_id`,
-      },
-      {
-        database: databaseName,
-        name: "TotalEventsMonthQuery",
-        description: "Total events over last month",
-        workgroup: workgroupName,
-        query: `WITH detail AS
-                (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, * 
-                FROM "${databaseName}"."${tableName}") 
-                SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT event_id) as event_count 
-                FROM detail 
-                GROUP BY date_trunc('month', event_month), application_id`,
-      },
-      {
-        database: databaseName,
-        name: "TotalIapTransactionsLastMonth",
-        description: "Total IAP Transactions over the last month",
-        workgroup: workgroupName,
-        query: `WITH detail AS 
-                (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day),'%Y-%m-%d'))) as event_month,* 
-                FROM "${databaseName}"."${tableName}") 
-                SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
-                FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
-                AND event_type = 'iap_transaction'
-                GROUP BY date_trunc('month', event_month), application_id`,
-      },
-      {
-        database: databaseName,
-        name: "NewUsersLastMonth",
-        description: "New Users over the last month",
-        workgroup: workgroupName,
-        query: `WITH detail AS (
-                SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, *
-                FROM "${databaseName}"."${tableName}")
-                SELECT
-                date_trunc('month', event_month) as month,
-                count(*) as new_accounts
-                FROM detail
-                WHERE event_type = 'user_registration'
-                GROUP BY date_trunc('month', event_month);`,
-      },
-      {
-        database: databaseName,
-        name: "TotalPlaysByLevel",
-        description: "Total number of times each level has been played",
-        workgroup: workgroupName,
-        query: `SELECT
-                json_extract_scalar(event_data, '$.level_id') as level,
-                count(json_extract_scalar(event_data, '$.level_id')) as number_of_plays
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type = 'level_started'
-                GROUP BY json_extract_scalar(event_data, '$.level_id')
-                ORDER by json_extract_scalar(event_data, '$.level_id');`,
-      },
-      {
-        database: databaseName,
-        name: "TotalFailuresByLevel",
-        description: "Total number of failures on each level",
-        workgroup: workgroupName,
-        query: `SELECT
-                json_extract_scalar(event_data, '$.level_id') as level,
-                count(json_extract_scalar(event_data, '$.level_id')) as number_of_failures
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type='level_failed'
-                GROUP BY json_extract_scalar(event_data, '$.level_id')
-                ORDER by json_extract_scalar(event_data, '$.level_id');`,
-      },
-      {
-        database: databaseName,
-        name: "TotalCompletionsByLevel",
-        description: "Total number of completions on each level",
-        workgroup: workgroupName,
-        query: `SELECT
-                json_extract_scalar(event_data, '$.level_id') as level,
-                count(json_extract_scalar(event_data, '$.level_id')) as number_of_completions
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type='level_completed'
-                GROUP BY json_extract_scalar(event_data, '$.level_id')
-                ORDER by json_extract_scalar(event_data, '$.level_id');`,
-      },
-      {
-        database: databaseName,
-        name: "LevelCompletionRate",
-        description: "Rate of completion for each level",
-        workgroup: workgroupName,
-        query: `with t1 as
-                (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type='level_started' GROUP BY json_extract_scalar(event_data, '$.level_id') 
-                ),
-                t2 as
-                (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
-                FROM "${databaseName}"."${tableName}"
-                WHERE event_type='level_completed'GROUP BY json_extract_scalar(event_data, '$.level_id') 
-                )
-                select t2.level, (cast(t2.level_count AS DOUBLE) / (cast(t2.level_count AS DOUBLE) + cast(t1.level_count AS DOUBLE))) * 100 as level_completion_rate from 
-                t1 JOIN t2 ON t1.level = t2.level
-                ORDER by level;`,
-      },
-      {
-        database: databaseName,
-        name: "AverageUserSentimentPerDay",
-        description: "User sentiment score by day",
-        workgroup: workgroupName,
-        query: `SELECT
-                avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
-                date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d')) as event_date
-                FROM "${databaseName}"."${tableName}"
-                WHERE json_extract_scalar(event_data, '$.user_rating') is not null
-                GROUP BY date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'));`,
-      },
-      {
-        database: databaseName,
-        name: "UserReportedReasonsCount",
-        description: "Reasons users are being reported, grouped by reason code",
-        workgroup: workgroupName,
-        query: `SELECT count(json_extract_scalar(event_data, '$.report_reason')) as count_of_reports, json_extract_scalar(event_data, '$.report_reason') as report_reason
-                FROM "${databaseName}"."${tableName}"
-                GROUP BY json_extract_scalar(event_data, '$.report_reason')
-                ORDER BY json_extract_scalar(event_data, '$.report_reason') DESC;`,
-      },
-      {
-        database: databaseName,
-        name: "CTASCreateIcebergTables",
-        description: "Create table as (CTAS) from existing tables to iceberg",
-        workgroup: workgroupName,
-        query: `CREATE TABLE "${databaseName}"."raw_events_iceberg"
-                WITH (table_type = 'ICEBERG',
-                    format = 'PARQUET', 
-                    location = 's3://your_bucket/', 
-                    is_external = false,
-                    partitioning = ARRAY['application_id', 'year', 'month', 'day'],
-                    vacuum_min_snapshots_to_keep = 10,
-                    vacuum_max_snapshot_age_seconds = 604800
-                ) 
-                AS SELECT * FROM "${databaseName}"."${tableName}";`,
-      },
-    ];
-  }
-
   private createDefaultAthenaQueries(
     databaseName: string,
     tableName: string,
     workgroupName: string,
     enableIceberg: boolean
   ) {
-    const queries = enableIceberg
-      ? this.buildIcebergQueries(databaseName, tableName, workgroupName)
-      : this.buildHiveQueries(databaseName, tableName, workgroupName);
+    const queries: QueryDefinition[] = [
+      {
+        name: "LatestEventsQuery",
+        description: "Get latest events by event_timestamp",
+        query: {
+          iceberg: `SELECT *, event_timestamp AT TIME ZONE 'America/New_York' as event_timestamp_america_new_york
+                    FROM "${databaseName}"."${tableName}"
+                    ORDER BY event_timestamp_america_new_york DESC
+                    LIMIT 10;`,
+          hive: `SELECT *, from_unixtime(event_timestamp, 'America/New_York') as event_timestamp_america_new_york
+                 FROM "${databaseName}"."${tableName}"
+                 ORDER BY event_timestamp_america_new_york DESC
+                 LIMIT 10;`,
+        },
+      },
+      {
+        name: "TotalEventsQuery",
+        description: "Total events",
+        query: `SELECT application_id, count(DISTINCT event_id) as event_count 
+                FROM "${databaseName}"."${tableName}"
+                GROUP BY application_id`,
+      },
+      {
+        name: "TotalEventsMonthQuery",
+        description: "Total events over last month",
+        query: {
+          iceberg: `WITH detail AS
+                    (SELECT date_trunc('month', event_timestamp) as event_month, * 
+                    FROM "${databaseName}"."${tableName}") 
+                    SELECT event_month as month, application_id, count(DISTINCT event_id) as event_count 
+                    FROM detail 
+                    GROUP BY event_month, application_id`,
+          hive: `WITH detail AS
+                 (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, * 
+                 FROM "${databaseName}"."${tableName}") 
+                 SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT event_id) as event_count 
+                 FROM detail 
+                 GROUP BY date_trunc('month', event_month), application_id`,
+        },
+      },
+      {
+        name: "TotalIapTransactionsLastMonth",
+        description: "Total IAP Transactions over the last month",
+        query: {
+          iceberg: `WITH detail AS 
+                    (SELECT date_trunc('month', event_timestamp) as event_month, * 
+                    FROM "${databaseName}"."${tableName}") 
+                    SELECT event_month as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
+                    FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
+                    AND event_type = 'iap_transaction'
+                    GROUP BY event_month, application_id`,
+          hive: `WITH detail AS 
+                 (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day),'%Y-%m-%d'))) as event_month,* 
+                 FROM "${databaseName}"."${tableName}") 
+                 SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
+                 FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
+                 AND event_type = 'iap_transaction'
+                 GROUP BY date_trunc('month', event_month), application_id`,
+        },
+      },
+      {
+        name: "NewUsersLastMonth",
+        description: "New Users over the last month",
+        query: {
+          iceberg: `WITH detail AS (
+                    SELECT date_trunc('month', event_timestamp) as event_month, *
+                    FROM "${databaseName}"."${tableName}")
+                    SELECT
+                    event_month as month,
+                    count(*) as new_accounts
+                    FROM detail
+                    WHERE event_type = 'user_registration'
+                    GROUP BY event_month;`,
+          hive: `WITH detail AS (
+                 SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, *
+                 FROM "${databaseName}"."${tableName}")
+                 SELECT
+                 date_trunc('month', event_month) as month,
+                 count(*) as new_accounts
+                 FROM detail
+                 WHERE event_type = 'user_registration'
+                 GROUP BY date_trunc('month', event_month);`,
+        },
+      },
+      {
+        name: "TotalPlaysByLevel",
+        description: "Total number of times each level has been played",
+        query: `SELECT
+                json_extract_scalar(event_data, '$.level_id') as level,
+                count(json_extract_scalar(event_data, '$.level_id')) as number_of_plays
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type = 'level_started'
+                GROUP BY json_extract_scalar(event_data, '$.level_id')
+                ORDER by json_extract_scalar(event_data, '$.level_id');`,
+      },
+      {
+        name: "TotalFailuresByLevel",
+        description: "Total number of failures on each level",
+        query: `SELECT
+                json_extract_scalar(event_data, '$.level_id') as level,
+                count(json_extract_scalar(event_data, '$.level_id')) as number_of_failures
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type='level_failed'
+                GROUP BY json_extract_scalar(event_data, '$.level_id')
+                ORDER by json_extract_scalar(event_data, '$.level_id');`,
+      },
+      {
+        name: "TotalCompletionsByLevel",
+        description: "Total number of completions on each level",
+        query: `SELECT
+                json_extract_scalar(event_data, '$.level_id') as level,
+                count(json_extract_scalar(event_data, '$.level_id')) as number_of_completions
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type='level_completed'
+                GROUP BY json_extract_scalar(event_data, '$.level_id')
+                ORDER by json_extract_scalar(event_data, '$.level_id');`,
+      },
+      {
+        name: "LevelCompletionRate",
+        description: "Rate of completion for each level",
+        query: `with t1 as
+                (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type='level_started' GROUP BY json_extract_scalar(event_data, '$.level_id') 
+                ),
+                t2 as
+                (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type='level_completed'GROUP BY json_extract_scalar(event_data, '$.level_id') 
+                )
+                select t2.level, (cast(t2.level_count AS DOUBLE) / (cast(t2.level_count AS DOUBLE) + cast(t1.level_count AS DOUBLE))) * 100 as level_completion_rate from 
+                t1 JOIN t2 ON t1.level = t2.level
+                ORDER by level;`,
+      },
+      {
+        name: "AverageUserSentimentPerDay",
+        description: "User sentiment score by day",
+        query: {
+          iceberg: `SELECT
+                    avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
+                    date(event_timestamp) as event_date
+                    FROM "${databaseName}"."${tableName}"
+                    WHERE json_extract_scalar(event_data, '$.user_rating') is not null
+                    GROUP BY date(event_timestamp);`,
+          hive: `SELECT
+                 avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
+                 date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d')) as event_date
+                 FROM "${databaseName}"."${tableName}"
+                 WHERE json_extract_scalar(event_data, '$.user_rating') is not null
+                 GROUP BY date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'));`,
+        },
+      },
+      {
+        name: "UserReportedReasonsCount",
+        description: "Reasons users are being reported, grouped by reason code",
+        query: `SELECT count(json_extract_scalar(event_data, '$.report_reason')) as count_of_reports, json_extract_scalar(event_data, '$.report_reason') as report_reason
+                FROM "${databaseName}"."${tableName}"
+                GROUP BY json_extract_scalar(event_data, '$.report_reason')
+                ORDER BY json_extract_scalar(event_data, '$.report_reason') DESC;`,
+      },
+      {
+        name: "CTASCreateIcebergTables",
+        description: "Create table as (CTAS) from existing tables to iceberg",
+        query: {
+          iceberg: `CREATE TABLE "${databaseName}"."raw_events_iceberg"
+                    WITH (table_type = 'ICEBERG',
+                        format = 'PARQUET', 
+                        location = 's3://your_bucket/', 
+                        is_external = false,
+                        partitioning = ARRAY['application_id', 'month(event_timestamp)'],
+                        vacuum_min_snapshots_to_keep = 10,
+                        vacuum_max_snapshot_age_seconds = 604800
+                    ) 
+                    AS SELECT * FROM "${databaseName}"."${tableName}";`,
+          hive: `CREATE TABLE "${databaseName}"."raw_events_iceberg"
+                 WITH (table_type = 'ICEBERG',
+                     format = 'PARQUET', 
+                     location = 's3://your_bucket/', 
+                     is_external = false,
+                     partitioning = ARRAY['application_id', 'year', 'month', 'day'],
+                     vacuum_min_snapshots_to_keep = 10,
+                     vacuum_max_snapshot_age_seconds = 604800
+                 ) 
+                 AS SELECT * FROM "${databaseName}"."${tableName}";`,
+        },
+      },
+    ];
 
-    for (const query of queries) {
-      new athena.CfnNamedQuery(this, `NamedQuery-${query.name}`, {
-        database: query.database,
-        name: query.name,
-        workGroup: query.workgroup,
-        description: query.description,
-        queryString: query.query,
+    for (const { name, description, query } of queries) {
+      const queryString =
+        typeof query === "string" ? query : enableIceberg ? query.iceberg : query.hive;
+
+      new athena.CfnNamedQuery(this, `NamedQuery-${name}`, {
+        database: databaseName,
+        name,
+        workGroup: workgroupName,
+        description,
+        queryString,
       });
     }
   }

--- a/infrastructure/aws-cdk/src/constructs/samples/athena-construct.ts
+++ b/infrastructure/aws-cdk/src/constructs/samples/athena-construct.ts
@@ -30,6 +30,14 @@ export interface AthenaQueryConstructProps extends cdk.StackProps {
 
 const defaultProps: Partial<AthenaQueryConstructProps> = {};
 
+interface AthenaNamedQuery {
+  database: string;
+  name: string;
+  description: string;
+  workgroup: string;
+  query: string;
+}
+
 /**
  * Deploys the Athena Sample Queries construct
  *
@@ -37,12 +45,16 @@ const defaultProps: Partial<AthenaQueryConstructProps> = {};
  */
 export class AthenaQueryConstruct extends Construct {
 
-  private createDefaultAthenaQueries(
+  /**
+   * Queries against the Iceberg-backed raw_events_table, where event_timestamp
+   * is a native timestamp column (no year/month/day partition columns).
+   */
+  private buildIcebergQueries(
     databaseName: string,
     tableName: string,
     workgroupName: string
-  ) {
-    const queries = [
+  ): AthenaNamedQuery[] {
+    return [
       {
         database: databaseName,
         name: "LatestEventsQuery",
@@ -199,6 +211,185 @@ export class AthenaQueryConstruct extends Construct {
                 AS SELECT * FROM "${databaseName}"."${tableName}";`,
       },
     ];
+  }
+
+  /**
+   * Queries against Hive-partitioned raw_events_table, where
+   * year/month/day are partition columns and event_timestamp is a Unix epoch.
+   */
+  private buildHiveQueries(
+    databaseName: string,
+    tableName: string,
+    workgroupName: string
+  ): AthenaNamedQuery[] {
+    return [
+      {
+        database: databaseName,
+        name: "LatestEventsQuery",
+        description: "Get latest events by event_timestamp",
+        workgroup: workgroupName,
+        query: `SELECT *, from_unixtime(event_timestamp, 'America/New_York') as event_timestamp_america_new_york
+                FROM "${databaseName}"."${tableName}"
+                ORDER BY event_timestamp_america_new_york DESC
+                LIMIT 10;`,
+      },
+      {
+        database: databaseName,
+        name: "TotalEventsQuery",
+        description: "Total events",
+        workgroup: workgroupName,
+        query: `SELECT application_id, count(DISTINCT event_id) as event_count 
+                FROM "${databaseName}"."${tableName}"
+                GROUP BY application_id`,
+      },
+      {
+        database: databaseName,
+        name: "TotalEventsMonthQuery",
+        description: "Total events over last month",
+        workgroup: workgroupName,
+        query: `WITH detail AS
+                (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, * 
+                FROM "${databaseName}"."${tableName}") 
+                SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT event_id) as event_count 
+                FROM detail 
+                GROUP BY date_trunc('month', event_month), application_id`,
+      },
+      {
+        database: databaseName,
+        name: "TotalIapTransactionsLastMonth",
+        description: "Total IAP Transactions over the last month",
+        workgroup: workgroupName,
+        query: `WITH detail AS 
+                (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day),'%Y-%m-%d'))) as event_month,* 
+                FROM "${databaseName}"."${tableName}") 
+                SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
+                FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
+                AND event_type = 'iap_transaction'
+                GROUP BY date_trunc('month', event_month), application_id`,
+      },
+      {
+        database: databaseName,
+        name: "NewUsersLastMonth",
+        description: "New Users over the last month",
+        workgroup: workgroupName,
+        query: `WITH detail AS (
+                SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, *
+                FROM "${databaseName}"."${tableName}")
+                SELECT
+                date_trunc('month', event_month) as month,
+                count(*) as new_accounts
+                FROM detail
+                WHERE event_type = 'user_registration'
+                GROUP BY date_trunc('month', event_month);`,
+      },
+      {
+        database: databaseName,
+        name: "TotalPlaysByLevel",
+        description: "Total number of times each level has been played",
+        workgroup: workgroupName,
+        query: `SELECT
+                json_extract_scalar(event_data, '$.level_id') as level,
+                count(json_extract_scalar(event_data, '$.level_id')) as number_of_plays
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type = 'level_started'
+                GROUP BY json_extract_scalar(event_data, '$.level_id')
+                ORDER by json_extract_scalar(event_data, '$.level_id');`,
+      },
+      {
+        database: databaseName,
+        name: "TotalFailuresByLevel",
+        description: "Total number of failures on each level",
+        workgroup: workgroupName,
+        query: `SELECT
+                json_extract_scalar(event_data, '$.level_id') as level,
+                count(json_extract_scalar(event_data, '$.level_id')) as number_of_failures
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type='level_failed'
+                GROUP BY json_extract_scalar(event_data, '$.level_id')
+                ORDER by json_extract_scalar(event_data, '$.level_id');`,
+      },
+      {
+        database: databaseName,
+        name: "TotalCompletionsByLevel",
+        description: "Total number of completions on each level",
+        workgroup: workgroupName,
+        query: `SELECT
+                json_extract_scalar(event_data, '$.level_id') as level,
+                count(json_extract_scalar(event_data, '$.level_id')) as number_of_completions
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type='level_completed'
+                GROUP BY json_extract_scalar(event_data, '$.level_id')
+                ORDER by json_extract_scalar(event_data, '$.level_id');`,
+      },
+      {
+        database: databaseName,
+        name: "LevelCompletionRate",
+        description: "Rate of completion for each level",
+        workgroup: workgroupName,
+        query: `with t1 as
+                (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type='level_started' GROUP BY json_extract_scalar(event_data, '$.level_id') 
+                ),
+                t2 as
+                (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
+                FROM "${databaseName}"."${tableName}"
+                WHERE event_type='level_completed'GROUP BY json_extract_scalar(event_data, '$.level_id') 
+                )
+                select t2.level, (cast(t2.level_count AS DOUBLE) / (cast(t2.level_count AS DOUBLE) + cast(t1.level_count AS DOUBLE))) * 100 as level_completion_rate from 
+                t1 JOIN t2 ON t1.level = t2.level
+                ORDER by level;`,
+      },
+      {
+        database: databaseName,
+        name: "AverageUserSentimentPerDay",
+        description: "User sentiment score by day",
+        workgroup: workgroupName,
+        query: `SELECT
+                avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
+                date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d')) as event_date
+                FROM "${databaseName}"."${tableName}"
+                WHERE json_extract_scalar(event_data, '$.user_rating') is not null
+                GROUP BY date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'));`,
+      },
+      {
+        database: databaseName,
+        name: "UserReportedReasonsCount",
+        description: "Reasons users are being reported, grouped by reason code",
+        workgroup: workgroupName,
+        query: `SELECT count(json_extract_scalar(event_data, '$.report_reason')) as count_of_reports, json_extract_scalar(event_data, '$.report_reason') as report_reason
+                FROM "${databaseName}"."${tableName}"
+                GROUP BY json_extract_scalar(event_data, '$.report_reason')
+                ORDER BY json_extract_scalar(event_data, '$.report_reason') DESC;`,
+      },
+      {
+        database: databaseName,
+        name: "CTASCreateIcebergTables",
+        description: "Create table as (CTAS) from existing tables to iceberg",
+        workgroup: workgroupName,
+        query: `CREATE TABLE "${databaseName}"."raw_events_iceberg"
+                WITH (table_type = 'ICEBERG',
+                    format = 'PARQUET', 
+                    location = 's3://your_bucket/', 
+                    is_external = false,
+                    partitioning = ARRAY['application_id', 'year', 'month', 'day'],
+                    vacuum_min_snapshots_to_keep = 10,
+                    vacuum_max_snapshot_age_seconds = 604800
+                ) 
+                AS SELECT * FROM "${databaseName}"."${tableName}";`,
+      },
+    ];
+  }
+
+  private createDefaultAthenaQueries(
+    databaseName: string,
+    tableName: string,
+    workgroupName: string,
+    enableIceberg: boolean
+  ) {
+    const queries = enableIceberg
+      ? this.buildIcebergQueries(databaseName, tableName, workgroupName)
+      : this.buildHiveQueries(databaseName, tableName, workgroupName);
 
     for (const query of queries) {
       new athena.CfnNamedQuery(this, `NamedQuery-${query.name}`, {
@@ -220,7 +411,8 @@ export class AthenaQueryConstruct extends Construct {
     this.createDefaultAthenaQueries(
       props.gameEventsDatabase.ref,
       props.config.RAW_EVENTS_TABLE,
-      props.gameAnalyticsWorkgroup.name
+      props.gameAnalyticsWorkgroup.name,
+      props.config.ENABLE_APACHE_ICEBERG_SUPPORT
     );
 
   }

--- a/infrastructure/terraform/src/constructs/samples/athena-construct/main.tf
+++ b/infrastructure/terraform/src/constructs/samples/athena-construct/main.tf
@@ -5,7 +5,7 @@ resource "aws_athena_named_query" "latest_events_query" {
   description = "Get latest events by event_timestamp"
   workgroup = var.game_events_workgroup
   query    = <<-EOT
-    SELECT *, from_unixtime(event_timestamp, 'America/New_York') as event_timestamp_america_new_york
+    SELECT *, event_timestamp AT TIME ZONE 'America/New_York' as event_timestamp_america_new_york
     FROM "${var.events_database}"."${var.raw_events_table}"
     ORDER BY event_timestamp_america_new_york DESC
     LIMIT 10;
@@ -31,11 +31,11 @@ resource "aws_athena_named_query" "total_events_month_query" {
   workgroup = var.game_events_workgroup
   query     = <<-EOT
     WITH detail AS
-    (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, * 
+    (SELECT date_trunc('month', event_timestamp) as event_month, * 
     FROM "${var.events_database}"."${var.raw_events_table}") 
-    SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT event_id) as event_count 
+    SELECT event_month as month, application_id, count(DISTINCT event_id) as event_count 
     FROM detail 
-    GROUP BY date_trunc('month', event_month), application_id;
+    GROUP BY event_month, application_id
   EOT
 }
 
@@ -46,12 +46,12 @@ resource "aws_athena_named_query" "total_iap_transactions_last_month_query" {
   workgroup = var.game_events_workgroup
   query     = <<-EOT
     WITH detail AS 
-    (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day),'%Y-%m-%d'))) as event_month,* 
+    (SELECT date_trunc('month', event_timestamp) as event_month, * 
     FROM "${var.events_database}"."${var.raw_events_table}") 
-    SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
+    SELECT event_month as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
     FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
     AND event_type = 'iap_transaction'
-    GROUP BY date_trunc('month', event_month), application_id;
+    GROUP BY event_month, application_id
   EOT
 }
 
@@ -62,14 +62,14 @@ resource "aws_athena_named_query" "new_users_last_month_query" {
   workgroup = var.game_events_workgroup
   query     = <<-EOT
     WITH detail AS (
-    SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, *
+    SELECT date_trunc('month', event_timestamp) as event_month, *
     FROM "${var.events_database}"."${var.raw_events_table}")
     SELECT
-    date_trunc('month', event_month) as month,
+    event_month as month,
     count(*) as new_accounts
     FROM detail
     WHERE event_type = 'user_registration'
-    GROUP BY date_trunc('month', event_month);
+    GROUP BY event_month;
   EOT
 }
 
@@ -146,11 +146,12 @@ resource "aws_athena_named_query" "average_user_sentiments_per_day_query" {
   description = "User sentiment score by day"
   workgroup = var.game_events_workgroup
   query     = <<-EOT
-    SELECT avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
-    date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d')) as event_date
+    SELECT
+    avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
+    date(event_timestamp) as event_date
     FROM "${var.events_database}"."${var.raw_events_table}"
     WHERE json_extract_scalar(event_data, '$.user_rating') is not null
-    GROUP BY date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'));
+    GROUP BY date(event_timestamp);
   EOT
 }
 
@@ -173,14 +174,14 @@ resource "aws_athena_named_query" "ctas_create_iceberg_tables_query" {
   description = "Create table as (CTAS) from existing tables to iceberg"
   workgroup = var.game_events_workgroup
   query     = <<-EOT
-    CREATE TABLE "${var.raw_events_table}"."raw_events_iceberg"
+    CREATE TABLE "${var.events_database}"."raw_events_iceberg"
     WITH (table_type = 'ICEBERG',
-      format = 'PARQUET', 
-      location = 's3://your_bucket/', 
-      is_external = false,
-      partitioning = ARRAY['application_id', 'year', 'month', 'day'],
-      vacuum_min_snapshots_to_keep = 10,
-      vacuum_max_snapshot_age_seconds = 604800
+    format = 'PARQUET', 
+    location = 's3://your_bucket/', 
+    is_external = false,
+    partitioning = ARRAY['application_id', 'month(event_timestamp)'],
+    vacuum_min_snapshots_to_keep = 10,
+    vacuum_max_snapshot_age_seconds = 604800
     ) 
     AS SELECT * FROM "${var.events_database}"."${var.raw_events_table}";
   EOT

--- a/infrastructure/terraform/src/constructs/samples/athena-construct/main.tf
+++ b/infrastructure/terraform/src/constructs/samples/athena-construct/main.tf
@@ -1,10 +1,22 @@
 # Create the Athena queries
-resource "aws_athena_named_query" "latest_events_query" {
-  name     = "LatestEventsQuery"
-  database = var.events_database
+#
+# Each named query has two variants controlled by var.enable_apache_iceberg_support:
+#   - *_iceberg: query targets the Iceberg schema, where event_timestamp is a
+#                native timestamp column (no year/month/day partitions).
+#   - *_hive:    query targets the legacy Hive-partitioned schema, where
+#                year/month/day are partition columns and event_timestamp is a
+#                Unix epoch integer.
+
+# --------------------------------------------------------------------------
+# LatestEventsQuery
+# --------------------------------------------------------------------------
+resource "aws_athena_named_query" "latest_events_query_iceberg" {
+  count       = var.enable_apache_iceberg_support ? 1 : 0
+  name        = "LatestEventsQuery"
+  database    = var.events_database
   description = "Get latest events by event_timestamp"
-  workgroup = var.game_events_workgroup
-  query    = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     SELECT *, event_timestamp AT TIME ZONE 'America/New_York' as event_timestamp_america_new_york
     FROM "${var.events_database}"."${var.raw_events_table}"
     ORDER BY event_timestamp_america_new_york DESC
@@ -12,24 +24,45 @@ resource "aws_athena_named_query" "latest_events_query" {
   EOT
 }
 
+resource "aws_athena_named_query" "latest_events_query_hive" {
+  count       = var.enable_apache_iceberg_support ? 0 : 1
+  name        = "LatestEventsQuery"
+  database    = var.events_database
+  description = "Get latest events by event_timestamp"
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
+    SELECT *, from_unixtime(event_timestamp, 'America/New_York') as event_timestamp_america_new_york
+    FROM "${var.events_database}"."${var.raw_events_table}"
+    ORDER BY event_timestamp_america_new_york DESC
+    LIMIT 10;
+  EOT
+}
+
+# --------------------------------------------------------------------------
+# TotalEventsQuery (schema-agnostic)
+# --------------------------------------------------------------------------
 resource "aws_athena_named_query" "total_events_query" {
-  name      = "TotalEventsQuery"
-  database  = var.events_database
+  name        = "TotalEventsQuery"
+  database    = var.events_database
   description = "Total events"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     SELECT application_id, count(DISTINCT event_id) as event_count 
     FROM "${var.events_database}"."${var.raw_events_table}"
     GROUP BY application_id;
   EOT
 }
 
-resource "aws_athena_named_query" "total_events_month_query" {
-  name      = "TotalEventsMonthQuery"
-  database  = var.events_database
+# --------------------------------------------------------------------------
+# TotalEventsMonthQuery
+# --------------------------------------------------------------------------
+resource "aws_athena_named_query" "total_events_month_query_iceberg" {
+  count       = var.enable_apache_iceberg_support ? 1 : 0
+  name        = "TotalEventsMonthQuery"
+  database    = var.events_database
   description = "Total events over last month"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     WITH detail AS
     (SELECT date_trunc('month', event_timestamp) as event_month, * 
     FROM "${var.events_database}"."${var.raw_events_table}") 
@@ -39,12 +72,32 @@ resource "aws_athena_named_query" "total_events_month_query" {
   EOT
 }
 
-resource "aws_athena_named_query" "total_iap_transactions_last_month_query" {
-  name      = "TotalIapTransactionsLastMonth"
-  database  = var.events_database
+resource "aws_athena_named_query" "total_events_month_query_hive" {
+  count       = var.enable_apache_iceberg_support ? 0 : 1
+  name        = "TotalEventsMonthQuery"
+  database    = var.events_database
+  description = "Total events over last month"
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
+    WITH detail AS
+    (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, * 
+    FROM "${var.events_database}"."${var.raw_events_table}") 
+    SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT event_id) as event_count 
+    FROM detail 
+    GROUP BY date_trunc('month', event_month), application_id
+  EOT
+}
+
+# --------------------------------------------------------------------------
+# TotalIapTransactionsLastMonth
+# --------------------------------------------------------------------------
+resource "aws_athena_named_query" "total_iap_transactions_last_month_query_iceberg" {
+  count       = var.enable_apache_iceberg_support ? 1 : 0
+  name        = "TotalIapTransactionsLastMonth"
+  database    = var.events_database
   description = "Total IAP Transactions over the last month"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     WITH detail AS 
     (SELECT date_trunc('month', event_timestamp) as event_month, * 
     FROM "${var.events_database}"."${var.raw_events_table}") 
@@ -55,12 +108,33 @@ resource "aws_athena_named_query" "total_iap_transactions_last_month_query" {
   EOT
 }
 
-resource "aws_athena_named_query" "new_users_last_month_query" {
-  name      = "NewUsersLastMonth"
-  database  = var.events_database
+resource "aws_athena_named_query" "total_iap_transactions_last_month_query_hive" {
+  count       = var.enable_apache_iceberg_support ? 0 : 1
+  name        = "TotalIapTransactionsLastMonth"
+  database    = var.events_database
+  description = "Total IAP Transactions over the last month"
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
+    WITH detail AS 
+    (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day),'%Y-%m-%d'))) as event_month,* 
+    FROM "${var.events_database}"."${var.raw_events_table}") 
+    SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
+    FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
+    AND event_type = 'iap_transaction'
+    GROUP BY date_trunc('month', event_month), application_id
+  EOT
+}
+
+# --------------------------------------------------------------------------
+# NewUsersLastMonth
+# --------------------------------------------------------------------------
+resource "aws_athena_named_query" "new_users_last_month_query_iceberg" {
+  count       = var.enable_apache_iceberg_support ? 1 : 0
+  name        = "NewUsersLastMonth"
+  database    = var.events_database
   description = "New Users over the last month"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     WITH detail AS (
     SELECT date_trunc('month', event_timestamp) as event_month, *
     FROM "${var.events_database}"."${var.raw_events_table}")
@@ -73,12 +147,34 @@ resource "aws_athena_named_query" "new_users_last_month_query" {
   EOT
 }
 
+resource "aws_athena_named_query" "new_users_last_month_query_hive" {
+  count       = var.enable_apache_iceberg_support ? 0 : 1
+  name        = "NewUsersLastMonth"
+  database    = var.events_database
+  description = "New Users over the last month"
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
+    WITH detail AS (
+    SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, *
+    FROM "${var.events_database}"."${var.raw_events_table}")
+    SELECT
+    date_trunc('month', event_month) as month,
+    count(*) as new_accounts
+    FROM detail
+    WHERE event_type = 'user_registration'
+    GROUP BY date_trunc('month', event_month);
+  EOT
+}
+
+# --------------------------------------------------------------------------
+# TotalPlaysByLevel (schema-agnostic)
+# --------------------------------------------------------------------------
 resource "aws_athena_named_query" "total_plays_by_level_query" {
-  name      = "TotalPlaysByLevel"
-  database  = var.events_database
+  name        = "TotalPlaysByLevel"
+  database    = var.events_database
   description = "Total number of times each level has been played"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     SELECT json_extract_scalar(event_data, '$.level_id') as level,
     count(json_extract_scalar(event_data, '$.level_id')) as number_of_plays
     FROM "${var.events_database}"."${var.raw_events_table}"
@@ -88,12 +184,15 @@ resource "aws_athena_named_query" "total_plays_by_level_query" {
   EOT
 }
 
+# --------------------------------------------------------------------------
+# TotalFailuresByLevel (schema-agnostic)
+# --------------------------------------------------------------------------
 resource "aws_athena_named_query" "total_failures_by_level_query" {
-  name      = "TotalFailuresByLevel"
-  database  = var.events_database
+  name        = "TotalFailuresByLevel"
+  database    = var.events_database
   description = "Total number of failures on each level"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     SELECT json_extract_scalar(event_data, '$.level_id') as level,
     count(json_extract_scalar(event_data, '$.level_id')) as number_of_failures
     FROM "${var.events_database}"."${var.raw_events_table}"
@@ -103,12 +202,15 @@ resource "aws_athena_named_query" "total_failures_by_level_query" {
   EOT
 }
 
+# --------------------------------------------------------------------------
+# TotalCompletionsByLevel (schema-agnostic)
+# --------------------------------------------------------------------------
 resource "aws_athena_named_query" "total_completions_by_level_query" {
-  name      = "TotalCompletionsByLevel"
-  database  = var.events_database
+  name        = "TotalCompletionsByLevel"
+  database    = var.events_database
   description = "Total number of completions on each level"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     SELECT json_extract_scalar(event_data, '$.level_id') as level,
     count(json_extract_scalar(event_data, '$.level_id')) as number_of_completions
     FROM "${var.events_database}"."${var.raw_events_table}"
@@ -118,12 +220,15 @@ resource "aws_athena_named_query" "total_completions_by_level_query" {
   EOT
 }
 
+# --------------------------------------------------------------------------
+# LevelCompletionRate (schema-agnostic)
+# --------------------------------------------------------------------------
 resource "aws_athena_named_query" "level_completion_rate_query" {
-  name      ="LevelCompletionRate"
-  database  = var.events_database
+  name        = "LevelCompletionRate"
+  database    = var.events_database
   description = "Rate of completion for each level"
-  workgroup = var.game_events_workgroup
-  query    = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     with t1 as
     (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
     FROM "${var.events_database}"."${var.raw_events_table}"
@@ -140,12 +245,16 @@ resource "aws_athena_named_query" "level_completion_rate_query" {
   EOT
 }
 
-resource "aws_athena_named_query" "average_user_sentiments_per_day_query" {
-  name      = "AverageUserSentimentPerDay"
-  database  = var.events_database
+# --------------------------------------------------------------------------
+# AverageUserSentimentPerDay
+# --------------------------------------------------------------------------
+resource "aws_athena_named_query" "average_user_sentiments_per_day_query_iceberg" {
+  count       = var.enable_apache_iceberg_support ? 1 : 0
+  name        = "AverageUserSentimentPerDay"
+  database    = var.events_database
   description = "User sentiment score by day"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     SELECT
     avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
     date(event_timestamp) as event_date
@@ -155,12 +264,31 @@ resource "aws_athena_named_query" "average_user_sentiments_per_day_query" {
   EOT
 }
 
+resource "aws_athena_named_query" "average_user_sentiments_per_day_query_hive" {
+  count       = var.enable_apache_iceberg_support ? 0 : 1
+  name        = "AverageUserSentimentPerDay"
+  database    = var.events_database
+  description = "User sentiment score by day"
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
+    SELECT
+    avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
+    date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d')) as event_date
+    FROM "${var.events_database}"."${var.raw_events_table}"
+    WHERE json_extract_scalar(event_data, '$.user_rating') is not null
+    GROUP BY date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'));
+  EOT
+}
+
+# --------------------------------------------------------------------------
+# UserReportedReasonsCount (schema-agnostic)
+# --------------------------------------------------------------------------
 resource "aws_athena_named_query" "user_reported_reasons_count_query" {
-  name      = "UserReportedReasonsCount"
-  database  = var.events_database
+  name        = "UserReportedReasonsCount"
+  database    = var.events_database
   description = "Reasons users are being reported, grouped by reason code"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     SELECT count(json_extract_scalar(event_data, '$.report_reason')) as count_of_reports, json_extract_scalar(event_data, '$.report_reason') as report_reason
     FROM "${var.events_database}"."${var.raw_events_table}"
     GROUP BY json_extract_scalar(event_data, '$.report_reason')
@@ -168,18 +296,42 @@ resource "aws_athena_named_query" "user_reported_reasons_count_query" {
   EOT
 }
 
-resource "aws_athena_named_query" "ctas_create_iceberg_tables_query" {
-  name      = "CTASCreateIcebergTables"
-  database  = var.events_database
+# --------------------------------------------------------------------------
+# CTASCreateIcebergTables
+# --------------------------------------------------------------------------
+resource "aws_athena_named_query" "ctas_create_iceberg_tables_query_iceberg" {
+  count       = var.enable_apache_iceberg_support ? 1 : 0
+  name        = "CTASCreateIcebergTables"
+  database    = var.events_database
   description = "Create table as (CTAS) from existing tables to iceberg"
-  workgroup = var.game_events_workgroup
-  query     = <<-EOT
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
     CREATE TABLE "${var.events_database}"."raw_events_iceberg"
     WITH (table_type = 'ICEBERG',
     format = 'PARQUET', 
     location = 's3://your_bucket/', 
     is_external = false,
     partitioning = ARRAY['application_id', 'month(event_timestamp)'],
+    vacuum_min_snapshots_to_keep = 10,
+    vacuum_max_snapshot_age_seconds = 604800
+    ) 
+    AS SELECT * FROM "${var.events_database}"."${var.raw_events_table}";
+  EOT
+}
+
+resource "aws_athena_named_query" "ctas_create_iceberg_tables_query_hive" {
+  count       = var.enable_apache_iceberg_support ? 0 : 1
+  name        = "CTASCreateIcebergTables"
+  database    = var.events_database
+  description = "Create table as (CTAS) from existing tables to iceberg"
+  workgroup   = var.game_events_workgroup
+  query       = <<-EOT
+    CREATE TABLE "${var.events_database}"."raw_events_iceberg"
+    WITH (table_type = 'ICEBERG',
+    format = 'PARQUET', 
+    location = 's3://your_bucket/', 
+    is_external = false,
+    partitioning = ARRAY['application_id', 'year', 'month', 'day'],
     vacuum_min_snapshots_to_keep = 10,
     vacuum_max_snapshot_age_seconds = 604800
     ) 

--- a/infrastructure/terraform/src/constructs/samples/athena-construct/main.tf
+++ b/infrastructure/terraform/src/constructs/samples/athena-construct/main.tf
@@ -1,340 +1,233 @@
 # Create the Athena queries
 #
-# Each named query has two variants controlled by var.enable_apache_iceberg_support:
-#   - *_iceberg: query targets the Iceberg schema, where event_timestamp is a
-#                native timestamp column (no year/month/day partitions).
-#   - *_hive:    query targets the legacy Hive-partitioned schema, where
-#                year/month/day are partition columns and event_timestamp is a
-#                Unix epoch integer.
+# Queries are defined in a single map. Each entry has:
+#   - description: shown in the Athena console
+#   - query:       the SQL string (for schema-agnostic queries)
+#   - query_iceberg / query_hive: schema-specific SQL variants, used when the
+#                                  query depends on the raw_events_table schema.
+#                                  Iceberg: event_timestamp is a native timestamp.
+#                                  Hive:    year/month/day are partition columns
+#                                           and event_timestamp is a Unix epoch.
+#
+# The resource below prefers the schema-specific variant and falls back to the
+# generic `query` field when only one was provided.
 
-# --------------------------------------------------------------------------
-# LatestEventsQuery
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "latest_events_query_iceberg" {
-  count       = var.enable_apache_iceberg_support ? 1 : 0
-  name        = "LatestEventsQuery"
-  database    = var.events_database
-  description = "Get latest events by event_timestamp"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT *, event_timestamp AT TIME ZONE 'America/New_York' as event_timestamp_america_new_york
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    ORDER BY event_timestamp_america_new_york DESC
-    LIMIT 10;
-  EOT
+locals {
+  athena_named_queries = {
+    LatestEventsQuery = {
+      description   = "Get latest events by event_timestamp"
+      query_iceberg = <<-EOT
+        SELECT *, event_timestamp AT TIME ZONE 'America/New_York' as event_timestamp_america_new_york
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        ORDER BY event_timestamp_america_new_york DESC
+        LIMIT 10;
+      EOT
+      query_hive    = <<-EOT
+        SELECT *, from_unixtime(event_timestamp, 'America/New_York') as event_timestamp_america_new_york
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        ORDER BY event_timestamp_america_new_york DESC
+        LIMIT 10;
+      EOT
+    }
+
+    TotalEventsQuery = {
+      description = "Total events"
+      query       = <<-EOT
+        SELECT application_id, count(DISTINCT event_id) as event_count 
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        GROUP BY application_id;
+      EOT
+    }
+
+    TotalEventsMonthQuery = {
+      description   = "Total events over last month"
+      query_iceberg = <<-EOT
+        WITH detail AS
+        (SELECT date_trunc('month', event_timestamp) as event_month, * 
+        FROM "${var.events_database}"."${var.raw_events_table}") 
+        SELECT event_month as month, application_id, count(DISTINCT event_id) as event_count 
+        FROM detail 
+        GROUP BY event_month, application_id
+      EOT
+      query_hive    = <<-EOT
+        WITH detail AS
+        (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, * 
+        FROM "${var.events_database}"."${var.raw_events_table}") 
+        SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT event_id) as event_count 
+        FROM detail 
+        GROUP BY date_trunc('month', event_month), application_id
+      EOT
+    }
+
+    TotalIapTransactionsLastMonth = {
+      description   = "Total IAP Transactions over the last month"
+      query_iceberg = <<-EOT
+        WITH detail AS 
+        (SELECT date_trunc('month', event_timestamp) as event_month, * 
+        FROM "${var.events_database}"."${var.raw_events_table}") 
+        SELECT event_month as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
+        FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
+        AND event_type = 'iap_transaction'
+        GROUP BY event_month, application_id
+      EOT
+      query_hive    = <<-EOT
+        WITH detail AS 
+        (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day),'%Y-%m-%d'))) as event_month,* 
+        FROM "${var.events_database}"."${var.raw_events_table}") 
+        SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
+        FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
+        AND event_type = 'iap_transaction'
+        GROUP BY date_trunc('month', event_month), application_id
+      EOT
+    }
+
+    NewUsersLastMonth = {
+      description   = "New Users over the last month"
+      query_iceberg = <<-EOT
+        WITH detail AS (
+        SELECT date_trunc('month', event_timestamp) as event_month, *
+        FROM "${var.events_database}"."${var.raw_events_table}")
+        SELECT
+        event_month as month,
+        count(*) as new_accounts
+        FROM detail
+        WHERE event_type = 'user_registration'
+        GROUP BY event_month;
+      EOT
+      query_hive    = <<-EOT
+        WITH detail AS (
+        SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, *
+        FROM "${var.events_database}"."${var.raw_events_table}")
+        SELECT
+        date_trunc('month', event_month) as month,
+        count(*) as new_accounts
+        FROM detail
+        WHERE event_type = 'user_registration'
+        GROUP BY date_trunc('month', event_month);
+      EOT
+    }
+
+    TotalPlaysByLevel = {
+      description = "Total number of times each level has been played"
+      query       = <<-EOT
+        SELECT json_extract_scalar(event_data, '$.level_id') as level,
+        count(json_extract_scalar(event_data, '$.level_id')) as number_of_plays
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        WHERE event_type = 'level_started'
+        GROUP BY json_extract_scalar(event_data, '$.level_id')
+        ORDER by json_extract_scalar(event_data, '$.level_id');
+      EOT
+    }
+
+    TotalFailuresByLevel = {
+      description = "Total number of failures on each level"
+      query       = <<-EOT
+        SELECT json_extract_scalar(event_data, '$.level_id') as level,
+        count(json_extract_scalar(event_data, '$.level_id')) as number_of_failures
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        WHERE event_type='level_failed'
+        GROUP BY json_extract_scalar(event_data, '$.level_id')
+        ORDER by json_extract_scalar(event_data, '$.level_id');
+      EOT
+    }
+
+    TotalCompletionsByLevel = {
+      description = "Total number of completions on each level"
+      query       = <<-EOT
+        SELECT json_extract_scalar(event_data, '$.level_id') as level,
+        count(json_extract_scalar(event_data, '$.level_id')) as number_of_completions
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        WHERE event_type='level_completed'
+        GROUP BY json_extract_scalar(event_data, '$.level_id')
+        ORDER by json_extract_scalar(event_data, '$.level_id');
+      EOT
+    }
+
+    LevelCompletionRate = {
+      description = "Rate of completion for each level"
+      query       = <<-EOT
+        with t1 as
+        (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        WHERE event_type='level_started' GROUP BY json_extract_scalar(event_data, '$.level_id') 
+        ),
+        t2 as
+        (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        WHERE event_type='level_completed'GROUP BY json_extract_scalar(event_data, '$.level_id') 
+        )
+        select t2.level, (cast(t2.level_count AS DOUBLE) / (cast(t2.level_count AS DOUBLE) + cast(t1.level_count AS DOUBLE))) * 100 as level_completion_rate from 
+        t1 JOIN t2 ON t1.level = t2.level
+        ORDER by level;
+      EOT
+    }
+
+    AverageUserSentimentPerDay = {
+      description   = "User sentiment score by day"
+      query_iceberg = <<-EOT
+        SELECT
+        avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
+        date(event_timestamp) as event_date
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        WHERE json_extract_scalar(event_data, '$.user_rating') is not null
+        GROUP BY date(event_timestamp);
+      EOT
+      query_hive    = <<-EOT
+        SELECT
+        avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
+        date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d')) as event_date
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        WHERE json_extract_scalar(event_data, '$.user_rating') is not null
+        GROUP BY date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'));
+      EOT
+    }
+
+    UserReportedReasonsCount = {
+      description = "Reasons users are being reported, grouped by reason code"
+      query       = <<-EOT
+        SELECT count(json_extract_scalar(event_data, '$.report_reason')) as count_of_reports, json_extract_scalar(event_data, '$.report_reason') as report_reason
+        FROM "${var.events_database}"."${var.raw_events_table}"
+        GROUP BY json_extract_scalar(event_data, '$.report_reason')
+        ORDER BY json_extract_scalar(event_data, '$.report_reason') DESC;
+      EOT
+    }
+
+    CTASCreateIcebergTables = {
+      description   = "Create table as (CTAS) from existing tables to iceberg"
+      query_iceberg = <<-EOT
+        CREATE TABLE "${var.events_database}"."raw_events_iceberg"
+        WITH (table_type = 'ICEBERG',
+        format = 'PARQUET', 
+        location = 's3://your_bucket/', 
+        is_external = false,
+        partitioning = ARRAY['application_id', 'month(event_timestamp)'],
+        vacuum_min_snapshots_to_keep = 10,
+        vacuum_max_snapshot_age_seconds = 604800
+        ) 
+        AS SELECT * FROM "${var.events_database}"."${var.raw_events_table}";
+      EOT
+      query_hive    = <<-EOT
+        CREATE TABLE "${var.events_database}"."raw_events_iceberg"
+        WITH (table_type = 'ICEBERG',
+        format = 'PARQUET', 
+        location = 's3://your_bucket/', 
+        is_external = false,
+        partitioning = ARRAY['application_id', 'year', 'month', 'day'],
+        vacuum_min_snapshots_to_keep = 10,
+        vacuum_max_snapshot_age_seconds = 604800
+        ) 
+        AS SELECT * FROM "${var.events_database}"."${var.raw_events_table}";
+      EOT
+    }
+  }
 }
 
-resource "aws_athena_named_query" "latest_events_query_hive" {
-  count       = var.enable_apache_iceberg_support ? 0 : 1
-  name        = "LatestEventsQuery"
-  database    = var.events_database
-  description = "Get latest events by event_timestamp"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT *, from_unixtime(event_timestamp, 'America/New_York') as event_timestamp_america_new_york
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    ORDER BY event_timestamp_america_new_york DESC
-    LIMIT 10;
-  EOT
-}
+resource "aws_athena_named_query" "queries" {
+  for_each = local.athena_named_queries
 
-# --------------------------------------------------------------------------
-# TotalEventsQuery (schema-agnostic)
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "total_events_query" {
-  name        = "TotalEventsQuery"
+  name        = each.key
   database    = var.events_database
-  description = "Total events"
   workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT application_id, count(DISTINCT event_id) as event_count 
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    GROUP BY application_id;
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# TotalEventsMonthQuery
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "total_events_month_query_iceberg" {
-  count       = var.enable_apache_iceberg_support ? 1 : 0
-  name        = "TotalEventsMonthQuery"
-  database    = var.events_database
-  description = "Total events over last month"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    WITH detail AS
-    (SELECT date_trunc('month', event_timestamp) as event_month, * 
-    FROM "${var.events_database}"."${var.raw_events_table}") 
-    SELECT event_month as month, application_id, count(DISTINCT event_id) as event_count 
-    FROM detail 
-    GROUP BY event_month, application_id
-  EOT
-}
-
-resource "aws_athena_named_query" "total_events_month_query_hive" {
-  count       = var.enable_apache_iceberg_support ? 0 : 1
-  name        = "TotalEventsMonthQuery"
-  database    = var.events_database
-  description = "Total events over last month"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    WITH detail AS
-    (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, * 
-    FROM "${var.events_database}"."${var.raw_events_table}") 
-    SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT event_id) as event_count 
-    FROM detail 
-    GROUP BY date_trunc('month', event_month), application_id
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# TotalIapTransactionsLastMonth
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "total_iap_transactions_last_month_query_iceberg" {
-  count       = var.enable_apache_iceberg_support ? 1 : 0
-  name        = "TotalIapTransactionsLastMonth"
-  database    = var.events_database
-  description = "Total IAP Transactions over the last month"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    WITH detail AS 
-    (SELECT date_trunc('month', event_timestamp) as event_month, * 
-    FROM "${var.events_database}"."${var.raw_events_table}") 
-    SELECT event_month as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
-    FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
-    AND event_type = 'iap_transaction'
-    GROUP BY event_month, application_id
-  EOT
-}
-
-resource "aws_athena_named_query" "total_iap_transactions_last_month_query_hive" {
-  count       = var.enable_apache_iceberg_support ? 0 : 1
-  name        = "TotalIapTransactionsLastMonth"
-  database    = var.events_database
-  description = "Total IAP Transactions over the last month"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    WITH detail AS 
-    (SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day),'%Y-%m-%d'))) as event_month,* 
-    FROM "${var.events_database}"."${var.raw_events_table}") 
-    SELECT date_trunc('month', event_month) as month, application_id, count(DISTINCT json_extract_scalar(event_data, '$.transaction_id')) as transaction_count 
-    FROM detail WHERE json_extract_scalar(event_data, '$.transaction_id') is NOT null 
-    AND event_type = 'iap_transaction'
-    GROUP BY date_trunc('month', event_month), application_id
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# NewUsersLastMonth
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "new_users_last_month_query_iceberg" {
-  count       = var.enable_apache_iceberg_support ? 1 : 0
-  name        = "NewUsersLastMonth"
-  database    = var.events_database
-  description = "New Users over the last month"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    WITH detail AS (
-    SELECT date_trunc('month', event_timestamp) as event_month, *
-    FROM "${var.events_database}"."${var.raw_events_table}")
-    SELECT
-    event_month as month,
-    count(*) as new_accounts
-    FROM detail
-    WHERE event_type = 'user_registration'
-    GROUP BY event_month;
-  EOT
-}
-
-resource "aws_athena_named_query" "new_users_last_month_query_hive" {
-  count       = var.enable_apache_iceberg_support ? 0 : 1
-  name        = "NewUsersLastMonth"
-  database    = var.events_database
-  description = "New Users over the last month"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    WITH detail AS (
-    SELECT date_trunc('month', date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'))) as event_month, *
-    FROM "${var.events_database}"."${var.raw_events_table}")
-    SELECT
-    date_trunc('month', event_month) as month,
-    count(*) as new_accounts
-    FROM detail
-    WHERE event_type = 'user_registration'
-    GROUP BY date_trunc('month', event_month);
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# TotalPlaysByLevel (schema-agnostic)
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "total_plays_by_level_query" {
-  name        = "TotalPlaysByLevel"
-  database    = var.events_database
-  description = "Total number of times each level has been played"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT json_extract_scalar(event_data, '$.level_id') as level,
-    count(json_extract_scalar(event_data, '$.level_id')) as number_of_plays
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    WHERE event_type = 'level_started'
-    GROUP BY json_extract_scalar(event_data, '$.level_id')
-    ORDER by json_extract_scalar(event_data, '$.level_id');
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# TotalFailuresByLevel (schema-agnostic)
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "total_failures_by_level_query" {
-  name        = "TotalFailuresByLevel"
-  database    = var.events_database
-  description = "Total number of failures on each level"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT json_extract_scalar(event_data, '$.level_id') as level,
-    count(json_extract_scalar(event_data, '$.level_id')) as number_of_failures
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    WHERE event_type='level_failed'
-    GROUP BY json_extract_scalar(event_data, '$.level_id')
-    ORDER by json_extract_scalar(event_data, '$.level_id');
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# TotalCompletionsByLevel (schema-agnostic)
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "total_completions_by_level_query" {
-  name        = "TotalCompletionsByLevel"
-  database    = var.events_database
-  description = "Total number of completions on each level"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT json_extract_scalar(event_data, '$.level_id') as level,
-    count(json_extract_scalar(event_data, '$.level_id')) as number_of_completions
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    WHERE event_type='level_completed'
-    GROUP BY json_extract_scalar(event_data, '$.level_id')
-    ORDER by json_extract_scalar(event_data, '$.level_id');
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# LevelCompletionRate (schema-agnostic)
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "level_completion_rate_query" {
-  name        = "LevelCompletionRate"
-  database    = var.events_database
-  description = "Rate of completion for each level"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    with t1 as
-    (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    WHERE event_type='level_started' GROUP BY json_extract_scalar(event_data, '$.level_id') 
-    ),
-    t2 as
-    (SELECT json_extract_scalar(event_data, '$.level_id') as level, count(json_extract_scalar(event_data, '$.level_id')) as level_count 
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    WHERE event_type='level_completed'GROUP BY json_extract_scalar(event_data, '$.level_id') 
-    )
-    select t2.level, (cast(t2.level_count AS DOUBLE) / (cast(t2.level_count AS DOUBLE) + cast(t1.level_count AS DOUBLE))) * 100 as level_completion_rate from 
-    t1 JOIN t2 ON t1.level = t2.level
-    ORDER by level;
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# AverageUserSentimentPerDay
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "average_user_sentiments_per_day_query_iceberg" {
-  count       = var.enable_apache_iceberg_support ? 1 : 0
-  name        = "AverageUserSentimentPerDay"
-  database    = var.events_database
-  description = "User sentiment score by day"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT
-    avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
-    date(event_timestamp) as event_date
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    WHERE json_extract_scalar(event_data, '$.user_rating') is not null
-    GROUP BY date(event_timestamp);
-  EOT
-}
-
-resource "aws_athena_named_query" "average_user_sentiments_per_day_query_hive" {
-  count       = var.enable_apache_iceberg_support ? 0 : 1
-  name        = "AverageUserSentimentPerDay"
-  database    = var.events_database
-  description = "User sentiment score by day"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT
-    avg(CAST(json_extract_scalar(event_data, '$.user_rating') AS real)) AS average_user_rating, 
-    date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d')) as event_date
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    WHERE json_extract_scalar(event_data, '$.user_rating') is not null
-    GROUP BY date(date_parse(CONCAT(year, '-', month, '-', day), '%Y-%m-%d'));
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# UserReportedReasonsCount (schema-agnostic)
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "user_reported_reasons_count_query" {
-  name        = "UserReportedReasonsCount"
-  database    = var.events_database
-  description = "Reasons users are being reported, grouped by reason code"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    SELECT count(json_extract_scalar(event_data, '$.report_reason')) as count_of_reports, json_extract_scalar(event_data, '$.report_reason') as report_reason
-    FROM "${var.events_database}"."${var.raw_events_table}"
-    GROUP BY json_extract_scalar(event_data, '$.report_reason')
-    ORDER BY json_extract_scalar(event_data, '$.report_reason') DESC;
-  EOT
-}
-
-# --------------------------------------------------------------------------
-# CTASCreateIcebergTables
-# --------------------------------------------------------------------------
-resource "aws_athena_named_query" "ctas_create_iceberg_tables_query_iceberg" {
-  count       = var.enable_apache_iceberg_support ? 1 : 0
-  name        = "CTASCreateIcebergTables"
-  database    = var.events_database
-  description = "Create table as (CTAS) from existing tables to iceberg"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    CREATE TABLE "${var.events_database}"."raw_events_iceberg"
-    WITH (table_type = 'ICEBERG',
-    format = 'PARQUET', 
-    location = 's3://your_bucket/', 
-    is_external = false,
-    partitioning = ARRAY['application_id', 'month(event_timestamp)'],
-    vacuum_min_snapshots_to_keep = 10,
-    vacuum_max_snapshot_age_seconds = 604800
-    ) 
-    AS SELECT * FROM "${var.events_database}"."${var.raw_events_table}";
-  EOT
-}
-
-resource "aws_athena_named_query" "ctas_create_iceberg_tables_query_hive" {
-  count       = var.enable_apache_iceberg_support ? 0 : 1
-  name        = "CTASCreateIcebergTables"
-  database    = var.events_database
-  description = "Create table as (CTAS) from existing tables to iceberg"
-  workgroup   = var.game_events_workgroup
-  query       = <<-EOT
-    CREATE TABLE "${var.events_database}"."raw_events_iceberg"
-    WITH (table_type = 'ICEBERG',
-    format = 'PARQUET', 
-    location = 's3://your_bucket/', 
-    is_external = false,
-    partitioning = ARRAY['application_id', 'year', 'month', 'day'],
-    vacuum_min_snapshots_to_keep = 10,
-    vacuum_max_snapshot_age_seconds = 604800
-    ) 
-    AS SELECT * FROM "${var.events_database}"."${var.raw_events_table}";
-  EOT
+  description = each.value.description
+  query       = var.enable_apache_iceberg_support ? try(each.value.query_iceberg, each.value.query) : try(each.value.query_hive, each.value.query)
 }

--- a/infrastructure/terraform/src/constructs/samples/athena-construct/variables.tf
+++ b/infrastructure/terraform/src/constructs/samples/athena-construct/variables.tf
@@ -1,11 +1,16 @@
 variable "events_database" {
-  type        = string
+  type = string
 }
 
 variable "game_events_workgroup" {
-  type        = string
+  type = string
 }
 
 variable "raw_events_table" {
-  type        = string
+  type = string
+}
+
+variable "enable_apache_iceberg_support" {
+  type        = bool
+  description = "When true, deploy queries targeting the Iceberg schema (native event_timestamp). When false, deploy legacy Hive-partitioned queries (year/month/day partition columns)."
 }

--- a/infrastructure/terraform/src/main.tf
+++ b/infrastructure/terraform/src/main.tf
@@ -587,6 +587,7 @@ module "athena_construct" {
   events_database = module.data_lake_construct[0].game_events_database_name
   game_events_workgroup = module.data_lake_construct[0].athena_workgroup_id
   raw_events_table = local.config.RAW_EVENTS_TABLE
+  enable_apache_iceberg_support = local.config.ENABLE_APACHE_ICEBERG_SUPPORT
 }
 
 // Creates firehose and logs related to ingestion


### PR DESCRIPTION
Refactors the sample Athena queries to use the event_timestamp column directly now that year/month/day partition columns are no longer present in raw_events_table.